### PR TITLE
fix J/m2 to MJ/ha

### DIFF
--- a/docs/rfactor.rst
+++ b/docs/rfactor.rst
@@ -70,7 +70,7 @@ Renard et al., 1997):
 
 .. math::
 
-    e_r = 29(1-0.72e^{-0.05i_r})
+    e_r = 0.29(1-0.72e^{-0.05i_r})
 
 The use of the type of relation has an important implication on the
 computation of the R-factor, as the sensitivity of the R-factor for extreme

--- a/docs/rfactor.rst
+++ b/docs/rfactor.rst
@@ -52,11 +52,12 @@ Energy per unit depth of rain
 There are number of ways to compute the rain energy per unit depth
 :math:`e_r`, depending on the area for which the R-factor is computed. For an
 application for Flanders/Belgium, the rain energy per unit is defined by
-(Salles et al., 1999, 2002, Verstraeten et al., 2006):
+(Salles et al., 1999, 2002, Verstraeten et al., 2006) (:math:`\text{MJ}.\text{mm}^{-1}.
+    \text{ha}^{-1}`):
 
 .. math::
 
-    e_r = 11.12i_r^{0.31}
+    e_r = 0.1112i_r^{0.31}
 
 with
 

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -37,7 +37,7 @@ def rain_energy_per_unit_depth_verstraeten2006(rain):
     Notes
     -----
     The rain energy per unit depth :math:`e_r` (:math:`\\text{MJ}.\\text{mm}^{-1}.
-    \\text{ha}^{-2}`) for an application for Flanders/Belgium is defined
+    \\text{ha}^{-1}`) for an application for Flanders/Belgium is defined
     by [1]_ , [2]_ and [3]_:
 
     .. math::

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -36,13 +36,13 @@ def rain_energy_per_unit_depth_verstraeten2006(rain):
 
     Notes
     -----
-    The rain energy per unit depth :math:`e_r` (:math:`\\text{J}.\\text{mm}^{-1}.
-    \\text{m}^{-2}`) for an application for Flanders/Belgium is defined
+    The rain energy per unit depth :math:`e_r` (:math:`\\text{MJ}.\\text{mm}^{-1}.
+    \\text{ha}^{-2}`) for an application for Flanders/Belgium is defined
     by [1]_ , [2]_ and [3]_:
 
     .. math::
 
-        e_r = 11.12i_r^{0.31}
+        e_r = 0.1112i_r^{0.31}
 
     with
 


### PR DESCRIPTION
The documentation of the energy function (Verstraeten/Salles) did not allign with the implementation : the unit and documented now are:

$\frac{MJ}{mm.ha}$

The formula is divided by 100 J/m2/mm to MJ/ha/mm

@SethCallewaert : this closes https://github.com/watem-sedem/rfactor/issues/81?