### PR TITLE
Don't implement shift on all_event_rain_cum

### DIFF
--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -461,8 +461,7 @@ def compute_erosivity(
         - **year** (int)
         - **tag** (str): unique tag for year, station-couple.
         - *event_rain_cum* (float): Cumulative rain for each event
-        - *all_events_cum* (float): Cumulative rain over all selected events together,
-          see note for interpretation.
+        - *all_events_cum* (float): Cumulative rain over the whole timeseries
         - *max_30min_intensity* (float): Maximal 30min intensity for each event
         - *event_energy* (float): Rain energy per unit depth for each event
         - *erosivity* (float): Erosivity for each event
@@ -471,9 +470,7 @@ def compute_erosivity(
     Notes
     -----
     1. NaN- and 0-values are removed from the input timeseries.
-    2. The ``all_event_rain_cum```contains the sum of all selected events with a depth
-       above a threshold (the minimum depth needed to retain event for erosivity
-       computation)
+
     """
     if not {"station", "rain_mm", "datetime"}.issubset(rain.columns):
         raise RFactorKeyError(

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -411,9 +411,7 @@ def _compute_erosivity(
 
     # cumulative rain over all events
     rain_events = rain_events.assign(
-        all_event_rain_cum=(
-            rain_events["event_rain_cum"].shift(1, fill_value=0.0).cumsum()
-        )
+        all_event_rain_cum=(rain_events["event_rain_cum"].cumsum())
     )
 
     # remove events below threshold
@@ -459,19 +457,23 @@ def compute_erosivity(
     all_erosivity: pandas.DataFrame
         DataFrame with erosivity output for each event.
 
-        - *datetime* (pandas.Timestamp): Time stamp
-        - *datetime* (pandas.Timestamp): Time stamp
+        - *station** (str)
+        - **year** (int)
+        - **tag** (str): unique tag for year, station-couple.
         - *event_rain_cum* (float): Cumulative rain for each event
+        - *all_events_cum* (float): Cumulative rain over all selected events together,
+          see note for interpretation.
         - *max_30min_intensity* (float): Maximal 30min intensity for each event
         - *event_energy* (float): Rain energy per unit depth for each event
         - *erosivity* (float): Erosivity for each event
-        - *all_events_cum* (float): Cumulative rain over all events together
         - *erosivity_cum* (float): Cumulative erosivity over all events together
-        - *tag* (str): unique tag for year, station-couple.
 
     Notes
     -----
-    NaN- and 0-values are removed from the input timeseries.
+    1. NaN- and 0-values are removed from the input timeseries.
+    2. The ``all_event_rain_cum```contains the sum of all selected events with a depth
+       above a threshold (the minimum depth needed to retain event for erosivity
+       computation)
     """
     if not {"station", "rain_mm", "datetime"}.issubset(rain.columns):
         raise RFactorKeyError(
@@ -517,4 +519,16 @@ def compute_erosivity(
     )
     all_erosivity.index = all_erosivity["datetime"]
 
-    return all_erosivity
+    return all_erosivity[
+        [
+            "station",
+            "year",
+            "tag",
+            "event_rain_cum",
+            "all_event_rain_cum",
+            "max_30min_intensity",
+            "event_energy",
+            "erosivity",
+            "erosivity_cum",
+        ]
+    ]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -21,7 +21,7 @@ from rfactor.process import (
 def test_days_since_last_year_float():
     """Moment of the day is translated as decimal number."""
     ts_series = pd.Series(
-        pd.date_range("2021-01-01 00:00", "2021-01-02 00:00", freq="6H")
+        pd.date_range("2021-01-01 00:00", "2021-01-02 00:00", freq="6h")
     )
     np.testing.assert_allclose(
         _days_since_start_year(ts_series).values, np.array([0.0, 0.25, 0.5, 0.75, 1.0])
@@ -31,7 +31,7 @@ def test_days_since_last_year_float():
 def test_days_since_last_year_single_year():
     """Data should all be from the same year."""
     ts_series = pd.Series(
-        pd.date_range("2020-12-31 00:00", "2021-01-02 00:00", freq="6H")
+        pd.date_range("2020-12-31 00:00", "2021-01-02 00:00", freq="6h")
     )
     with pytest.raises(Exception):
         _days_since_start_year(ts_series)

--- a/tests/test_rfactor.py
+++ b/tests/test_rfactor.py
@@ -173,14 +173,14 @@ def test_erosivity_rain_single_yearstation(dummy_rain):
 
     # year column added when not existing
     assert "year" in erosivity.columns
-    assert erosivity["year"][0] == 2018
+    assert erosivity["year"].iloc[0] == 2018
 
     # station column preserved
-    assert erosivity["station"][0] == "P01_001"
+    assert erosivity["station"].iloc[0] == "P01_001"
 
     # tag column added when not existing
     assert "tag" in erosivity.columns
-    assert erosivity["tag"][0] == "P01_001_2018"
+    assert erosivity["tag"].iloc[0] == "P01_001_2018"
 
 
 def test_erosivity_rain_single_yearstation_wrong_datetime_dtype(dummy_rain):
@@ -227,7 +227,7 @@ def test_erosivity_existing_tag(dummy_rain):
     dummy_rain["tag"] = "MY_UNIQUE_TAG"
     erosivity = compute_erosivity(dummy_rain)
     assert "tag" in erosivity.columns
-    assert erosivity["tag"][0] == "MY_UNIQUE_TAG"
+    assert erosivity["tag"].iloc[0] == "MY_UNIQUE_TAG"
 
 
 @pytest.mark.parametrize(
@@ -273,7 +273,18 @@ def test_rfactor_benchmark_single_year(
         (eros_benchmark["year"] == year) & (eros_benchmark["station"] == station)
     ]
 
-    pd.testing.assert_frame_equal(erosivity, erosivity_reference)
+    # only test specific columns
+    cols = [
+        "event_rain_cum",
+        "max_30min_intensity",
+        "event_energy",
+        "erosivity",
+        "erosivity_cum",
+        "station",
+        "year",
+        "tag",
+    ]
+    pd.testing.assert_frame_equal(erosivity[cols], erosivity_reference[cols])
 
     # using support function provides the same output
     erosivity_support_func = _compute_erosivity(
@@ -283,9 +294,16 @@ def test_rfactor_benchmark_single_year(
     )
 
     erosivity_support_func.index = erosivity_support_func["datetime"]
-    pd.testing.assert_frame_equal(
-        erosivity.drop(columns=["tag", "station", "year"]), erosivity_support_func
-    )
+
+    # only test specific columns
+    cols = [
+        "event_rain_cum",
+        "max_30min_intensity",
+        "event_energy",
+        "erosivity",
+        "erosivity_cum",
+    ]
+    pd.testing.assert_frame_equal(erosivity[cols], erosivity_support_func[cols])
 
 
 @pytest.mark.skip(reason="only works with full data set (not in package")

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -6,7 +6,7 @@ from rfactor.valid import valid_column, valid_const_freq, valid_freq
 
 def test_valid_rainfall_timeseries():
     """Test subfunctionalities of valid_rainfall_timeseries decorator"""
-    idx = pd.date_range("2018-01-01 03:30", periods=2, freq="1S")
+    idx = pd.date_range("2018-01-01 03:30", periods=2, freq="1s")
     val = [0.06, 0.08]
 
     df = pd.DataFrame(columns=["datetime", "rain_mm"])
@@ -23,7 +23,7 @@ def test_valid_rainfall_timeseries():
         valid_freq(freq)
     assert "Please define a frequency for your input timeseries" in str(excinfo.value)
 
-    df.index.freq = "1S"
+    df.index.freq = "1s"
     freq = df.index.freq
 
     with pytest.raises(IOError) as excinfo:


### PR DESCRIPTION
See https://github.com/watem-sedem/rfactor/issues/100

- all_event_rain_cum for row x is now the cumulative rainfall over the events up untill x +  the cumulative rainfall of the current event at row x, simarly as erosivity_cum is computed.
- tests are adapted to test on specific columns in test_rfactor_benchmark_single_year
- depr. warnings in test code is handled