### PR TITLE
Make sure no extrapolation is done at dataset tails

### DIFF
--- a/src/rfactor/rain.py
+++ b/src/rfactor/rain.py
@@ -325,7 +325,8 @@ def load_rain_file_flanders(
         indices_to_remove = df_temp[df_temp].index
         df = df.drop(index=indices_to_remove)
         # Interpolate the remaining NaN-values
-        df["rain_mm"] = df["rain_mm"].interpolate(method=interpolate)
+        df["rain_mm"] = df["rain_mm"].interpolate(method=interpolate, 
+                                                 limit_area='inside')
 
     # remove 0 values
     df = df[df["rain_mm"] > 0]

--- a/src/rfactor/rain.py
+++ b/src/rfactor/rain.py
@@ -333,8 +333,9 @@ def load_rain_file_flanders(
             # behaviour of 'pad' is the same as pandas.DataFrame.ffill
             df["rain_mm"] = df["rain_mm"].ffill()
         else:
-            df["rain_mm"] = df["rain_mm"].interpolate(method=interpolate, 
-                                                      limit_area='inside')
+            df["rain_mm"] = df["rain_mm"].interpolate(
+                method=interpolate, limit_area="inside"
+            )
 
     # remove 0 values
     df = df[df["rain_mm"] > 0]

--- a/src/rfactor/rain.py
+++ b/src/rfactor/rain.py
@@ -325,8 +325,9 @@ def load_rain_file_flanders(
         indices_to_remove = df_temp[df_temp].index
         df = df.drop(index=indices_to_remove)
         # Interpolate the remaining NaN-values
-        df["rain_mm"] = df["rain_mm"].interpolate(method=interpolate, 
-                                                 limit_area='inside')
+        df["rain_mm"] = df["rain_mm"].interpolate(
+            method=interpolate, limit_area='inside'
+        )
 
     # remove 0 values
     df = df[df["rain_mm"] > 0]


### PR DESCRIPTION
In order to limit overshooting in the dataset due to lacking values at the beginning of end of the datasets, a limit is set to only interpolate between measurements and not fill in the missing values at tails of the dataset. This only impacts the methodology used in the Flanders use-case: namely the rain_file_load-function for Flanders.