### PR TITLE
only run for a given python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         pytest
     - name: Test with tox (except full benchmark)
       run: |
-        tox -- -m "not slow"
+        tox -e py$(echo "${{ matrix.python-version }}" | tr -d '.') -- -m "not slow"
     - name: Check docstring coverage
       run: |
         tox -e interrogate


### PR DESCRIPTION
The issue is that tox -- -m "not slow" runs all configured tox environments (py311, py312, py313). It should target only the environment matching the current matrix Python version. hence, arguments to specifiy python to be used are added to tox command.


https://github.com/watem-sedem/rfactor/blob/862430083f0b1e22682e375ab3657ee8f7651ed4/.github/workflows/ci.yml#L40-L42

See the duplicate pytest in python3.13 pipeline (run for 3.12 and 3.13) -> https://github.com/watem-sedem/rfactor/actions/runs/26890828335/job/79316035834#step:8:29
